### PR TITLE
feat: サンプルコードとデバッグ手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,49 @@
 ## kintoneアプリのフィールド情報から型情報を生成する
 
 [cybozu.dev](https://cybozu.dev/ja/id/9d7aff6319d6de6a821d142d/#generate-information-of-type)
+
+## ブラウザデバッグ
+
+1. 実行中のブラウザに接続する。
+
+    ```bat
+    msedge.exe --remote-debugging-port=9222 --user-data-dir=remote-debug-profile
+    netstat -a | findstr :9222
+    ```
+
+    - 起動中のブラウザはすべて閉じていること
+    - [code.visualstudio.com](https://code.visualstudio.com/docs/nodejs/browser-debugging#_attaching-to-browsers)
+
+2. ビルド実行
+
+    `npm run build` を実行し、`dist/sample.js` を作成する。
+
+3. kintoneアプリの設定より`dist/sample.js` を**アップロード**または**URL指定で追加**。
+4. vscodeの実行とデバッグを開き、以下の内容を`.vscode/launch.json`に記載する。その後、`Attach to Edge` をクリックする。
+
+    ```
+    {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Attach to Edge",
+                "port": 9222,
+                "request": "attach",
+                "type": "msedge",
+                "webRoot": "${workspaceFolder}"
+            }
+        ]
+    }
+    ```
+
+5. `sample.ts` にブレイクポイントを設定する。
+6. kintoneの一覧を表示すると設定したブレイクポイントで止まります。
+
+## トラブルシューティング
+
+### 9222ポートが開かない
+
+設定 -> システムとパフォーマンス -> システム を開き、以下の設定項目をOFFにする。
+
+- スタートアップ ブースト
+- Edgeを閉じたときにバックグラウンド拡張機能とアプリの実行を続ける

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "## Live Server Extensionを使う",
   "main": "index.js",
   "scripts": {
-    "start": "npx webpack-cli --mode development --color --watch",
+    "build": "npx webpack-cli --mode development --color --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/sample.ts
+++ b/src/sample.ts
@@ -1,0 +1,10 @@
+(function() {
+    "use strict";
+
+    // レコード一覧画面の表示イベント
+    kintone.events.on('app.record.index.show', function(event) {
+        console.log('レコード一覧画面が表示されました');
+        // カスタマイズ処理をここに記述
+        return event;
+    });
+})();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,10 @@ const path = require('path');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 module.exports = {
+  mode: "development",
+  devtool: "inline-source-map",
   entry: {
+    'sample': './src/sample.ts',
     'crc32': './src/crc32.ts',
     'trace-back-to-grandparents': './src/trace-back-to-grandparents.ts'
   },


### PR DESCRIPTION
開発者がTypeScriptでのkintoneカスタマイズ開発をスムーズに開始できるよう、サンプルコードとデバッグ環境の構築手順を追加する。

主な変更点:
- レコード一覧画面イベントをフックするサンプルコード(sample.ts)を追加
- sample.tsをビルドし、ソースマップを出力するようwebpack.config.jsを更新
- README.mdにVSCodeとEdgeを使ったブラウザデバッグの詳細な手順を記載
- npm scriptの"start"を"build"にリネームし、役割を明確化