### PR TITLE
feat(dev-env): kintoneカスタマイズアップローダーの環境を構築

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ npx kintone-dts-gen --base-url https://sample.cybozu.com \
 
 [cybozu.dev](https://cybozu.dev/ja/id/9d7aff6319d6de6a821d142d/#generate-information-of-type)
 
+## kintoneへ適用する
+
+マニフェストファイルを作成し、CSSやJavaScriptファイルをkintoneへアップロード
+
+```sh
+mise install
+mise run
+```
+
+[cybozu.dev](https://cybozu.dev/ja/kintone/sdk/development-environment/customize-uploader/)
+
 ## ブラウザデバッグ
 
 1. 実行中のブラウザに接続する。

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,15 @@
+[env]
+KINTONE_BASE_URL = "https://sample.cybozu.com"
+KINTONE_USERNAME = "ログイン名"
+KINTONE_PASSWORD = "パスワード"
+
+[tools]
+"npm:@kintone/customize-uploader" = "latest"
+
+[tasks.init]
+description = "マニフェストファイルの作成"
+run = "kintone-customize-uploader --dest-dir ./dist init"
+
+[tasks.upload]
+description = "カスタマイズの適用"
+run = "kintone-customize-uploader dist/customize-manifest.json"


### PR DESCRIPTION
kintone-customize-uploader と mise を使用して、kintoneへのカスタマイズ適用を効率化する環境を構築しました。

主な変更点:
- `mise.toml` を追加し、kintone-customize-uploader のインストールとタスクを定義
- `README.md` に、セットアップとアップロード手順を追記