### PR TITLE
fix(tsconfig): TypeScriptの型解決設定を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,12 @@
       "target": "es5",
       "module": "es2015",
       "strict": true,
-      "moduleResolution": "node"
+      "moduleResolution": "node",
+      "lib": [
+        "dom",
+        "es2020"
+      ],
+      "types": []
     },
     "files" : [
       "./node_modules/@kintone/dts-gen/kintone.d.ts",


### PR DESCRIPTION
TypeScriptのビルド環境における型定義の競合と不足を解消するため、tsconfig.json を修正します。

- compilerOptions.types を [] に設定
  - @types/node が自動で読み込まれるのを防ぎ、setTimeout の返り値が NodeJS.Timeout になる問題を解消。

- compilerOptions.lib に "es2020" を追加
  - padStart や Promise.allSettled など、モダンなJavaScript機能の型定義を提供。
